### PR TITLE
🔀 metadata 수리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,11 @@
-"use client";
-
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { ThemeProvider } from "styled-components";
-import { theme } from "./style";
 import "./style/globals.css";
+import Provider from "./provider";
 
 const inter = Inter({ subsets: ["latin"] });
 
-export const MisoMetadata: Metadata = {
+export const metadata: Metadata = {
   title: "Miso Admin",
   description: "미소의 관리자 전용 페이지입니다.",
   icons: {
@@ -22,10 +19,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ThemeProvider theme={theme}>
-      <html lang="en">
+    <html lang="en">
+      <Provider>
         <body className={inter.className}>{children}</body>
-      </html>
-    </ThemeProvider>
+      </Provider>
+    </html>
   );
 }

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ThemeProvider } from "styled-components";
+import { theme } from "./style";
+
+export default function Provider({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}


### PR DESCRIPTION
## 💡 개요
기존에 styled-component의 provide와 충돌을 일으켜 metadata가 작동하지 않았습니다.

## 📃 작업내용
 - provide 파일을 분리하였습니다.